### PR TITLE
Fix installer.sh network check

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -617,9 +617,9 @@ fi
 
 # Network should be configured allowing access to remote servers at this point
 #
-wget http://www.thethingsnetwork.org/ --no-check-certificate -O /dev/null -o /dev/null
+wget https://account.thethingsnetwork.org/ --no-check-certificate -O /dev/null -o /dev/null
 if [ $? -ne 0 ] ; then
-	echo "Error in network settings, cannot access www.thethingsnetwork.org"
+	echo "Error in network settings, cannot access account.thethingsnetwork.org"
 	echo "Check network settings and rerun this script to correct the setup"
 	grep -v network $STATUSFILE > $STATUSFILE.tmp
 	mv $STATUSFILE.tmp $STATUSFILE


### PR DESCRIPTION
The installer.sh script checks whether network is available. This check is broken:
```
root@mtcdt:~# wget http://www.thethingsnetwork.org/
--2019-07-26 13:11:13--  http://www.thethingsnetwork.org/
Resolving www.thethingsnetwork.org... 168.63.126.95
Connecting to www.thethingsnetwork.org|168.63.126.95|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://www.thethingsnetwork.org/ [following]
--2019-07-26 13:11:13--  https://www.thethingsnetwork.org/
Connecting to www.thethingsnetwork.org|168.63.126.95|:443... connected.
HTTP request sent, awaiting response... 502 Bad Gateway
2019-07-26 13:11:13 ERROR 502: Bad Gateway.
```

If you would add a User-Agent header, the 502 error goes a way, but I don't like to fake this header. A few alternatives are possible, like checking github.com or account.thethingsnetwork.org instead. I propose the latter as it is also used at a later point in the script. 